### PR TITLE
Add auth handler

### DIFF
--- a/functions/auth.ts
+++ b/functions/auth.ts
@@ -1,0 +1,44 @@
+import { AuthHandler, LinkAdapter, Session } from "sst/node/auth";
+
+declare module "sst/node/auth" {
+  export interface SessionTypes {
+    user: {
+      userID: string;
+    };
+  }
+}
+
+export const handler = AuthHandler({
+  providers: {
+    // Frontend
+    // location.href =
+    //  "https://api.example.com/auth/link/authorize?email=user@example.com";
+    link: LinkAdapter({
+      onLink: async (link, claims) => {
+        console.log({ link, claims });
+        return {
+          statusCode: 200,
+          body: JSON.stringify({ link }),
+        };
+      },
+      onSuccess: async (claims) => {
+        console.log({ claims });
+        // https://example.com/?token=XXXXXX
+        return Session.parameter({
+          redirect: "https://example.com",
+          type: "user",
+          properties: {
+            userID: "1234",
+          },
+        });
+      },
+      onError: async () => {
+        console.log("ERROR!");
+        return {
+          statusCode: 500,
+          body: JSON.stringify({ message: "there was an error" }),
+        };
+      },
+    }),
+  },
+});

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -2,6 +2,7 @@ import { SSTConfig } from "sst";
 import { API } from "./stacks/API";
 import { Database } from "./stacks/Database";
 import { Site } from "./stacks/Site";
+import { Authentication } from "./stacks/Authentication";
 
 export default {
   config(_input) {
@@ -13,6 +14,7 @@ export default {
   stacks(app) {
     app.stack(Database);
     app.stack(API);
+    app.stack(Authentication);
     app.stack(Site);
   },
 } satisfies SSTConfig;


### PR DESCRIPTION
This is the first step to #18 and adds an endpoint to start the authentication flow via [SST's magic link adaptor](https://docs.sst.dev/auth#magic-links).

If you go to (`GET`) `https://API_BASE_URL/auth/link/authorize?email=user@example.com`, you'll be provided a link. When you go to that link, it'll redirect you to `https://example.com/?token=XXXXXX` with the encoded JWT token to save