### PR TITLE
Replace magic links with GitHub OAuth and IDs

### DIFF
--- a/functions/auth.ts
+++ b/functions/auth.ts
@@ -1,4 +1,5 @@
-import { AuthHandler, LinkAdapter, Session } from "sst/node/auth";
+import { AuthHandler, GithubAdapter, Session } from "sst/node/auth";
+import { Config } from "sst/node/config";
 
 declare module "sst/node/auth" {
   export interface SessionTypes {
@@ -10,20 +11,38 @@ declare module "sst/node/auth" {
 
 export const handler = AuthHandler({
   providers: {
-    // Frontend
-    // location.href =
-    //  "https://api.example.com/auth/link/authorize?email=user@example.com";
-    link: LinkAdapter({
-      onLink: async (link, claims) => {
-        console.log({ link, claims });
-        return {
-          statusCode: 200,
-          body: JSON.stringify({ link }),
-        };
-      },
-      onSuccess: async (claims) => {
-        console.log({ claims });
-        // https://example.com/?token=XXXXXX
+    /*
+      Start of flow: /auth/github/authorize
+      eg: https://j7tgyxxjg4.execute-api.us-east-1.amazonaws.com/auth/github/authorize
+
+      Callback: /auth/github/callback
+
+      >>> requests.get('https://api.github.com/user', headers={"Authorization": "Bearer ghu_XXXXXXX"})
+    */
+    github: GithubAdapter({
+      clientID: Config.GITHUB_CLIENT_ID,
+      clientSecret: Config.GITHUB_CLIENT_SECRET,
+      scope: "", // empty = read only, public values
+      onSuccess: async (tokenset, client) => {
+        console.log({ tokenset, client });
+
+        const accessToken = tokenset.access_token;
+        const response = await fetch("https://api.github.com/user", {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+        const body = await response.json();
+
+        const userGitHubId = body.id;
+        // TODO: from here, find our user ID based on github ID, and
+        //       return a Session.parameter with our user ID
+
+        console.log({ response });
+        console.log({ body });
+        console.log({ userGitHubId });
+
         return Session.parameter({
           redirect: "https://example.com",
           type: "user",
@@ -31,13 +50,6 @@ export const handler = AuthHandler({
             userID: "1234",
           },
         });
-      },
-      onError: async () => {
-        console.log("ERROR!");
-        return {
-          statusCode: 500,
-          body: JSON.stringify({ message: "there was an error" }),
-        };
       },
     }),
   },

--- a/functions/core/entities/user.ts
+++ b/functions/core/entities/user.ts
@@ -101,5 +101,17 @@ export async function create(props: CreateProperties) {
 
   // Transaction writes can't return the values, so we have to query for them by email
   const user = await User.query.byGithubId({ githubId: props.githubId }).go();
-  return user.data;
+  return user.data[0];
+}
+
+export async function findOrCreateByGithubId(githubId: number) {
+  const foundUser = await User.query.byGithubId({ githubId }).go();
+  console.log({ foundUser });
+  if (foundUser.data.length > 0) {
+    console.log("Returning known user");
+    return foundUser.data[0];
+  }
+
+  console.log("Creating new user");
+  return create({ githubId });
 }

--- a/functions/core/entities/user.ts
+++ b/functions/core/entities/user.ts
@@ -1,23 +1,10 @@
 import { Constraint } from "@/functions/core/entities/constraint";
 import { Dynamo } from "@/functions/core/dynamo";
-import { Entity, Service } from "electrodb";
+import { CreateEntityItem, Entity, Service } from "electrodb";
 import { ulid } from "ulid";
 import { serviceName } from "@/functions/core/service";
 
-/* RFC 5322 Format
-   See: https://stackabuse.com/validate-email-addresses-with-regular-expressions-in-javascript/
-*/
-const validEmailRegex =
-  /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-
-export class EmailNotUniqueError extends Error {}
-
-const validateEmail = (email: string) => {
-  const isValid = validEmailRegex.test(email);
-  if (!isValid) {
-    return "Invalid email address";
-  }
-};
+export class GithubIdNotUniqueError extends Error {}
 
 export const User = new Entity(
   {
@@ -31,10 +18,9 @@ export const User = new Entity(
         type: "string",
         required: true,
       },
-      email: {
-        type: "string",
+      githubId: {
+        type: "number",
         required: true,
-        validate: validateEmail,
       },
       createdAt: {
         type: "number",
@@ -59,11 +45,11 @@ export const User = new Entity(
           composite: [],
         },
       },
-      byEmail: {
+      byGithubId: {
         index: "gsi1",
         pk: {
           field: "gsi1pk",
-          composite: ["email"],
+          composite: ["githubId"],
         },
         sk: {
           field: "gsi1sk",
@@ -82,7 +68,9 @@ export const User = new Entity(
   Dynamo.Configuration
 );
 
-export async function create(email: string) {
+type CreateProperties = Omit<CreateEntityItem<typeof User>, "userId">;
+
+export async function create(props: CreateProperties) {
   // Enforce unique email constraint on users
   const userConstraintService = new Service(
     {
@@ -97,21 +85,21 @@ export async function create(email: string) {
     .write(({ User, Constraint }) => [
       User.create({
         userId: ulid(),
-        email,
+        githubId: props.githubId,
       }).commit(),
       Constraint.create({
-        name: "email",
-        value: email,
+        name: "user-githubId",
+        value: props.githubId.toString(),
         entity: User.schema.model.entity,
       }).commit(),
     ])
     .go();
 
   if (result.canceled) {
-    throw new EmailNotUniqueError(`Could not create user: ${result.data}`);
+    throw new GithubIdNotUniqueError(`Could not create user: ${result.data}`);
   }
 
   // Transaction writes can't return the values, so we have to query for them by email
-  const user = await User.query.byEmail({ email }).go();
+  const user = await User.query.byGithubId({ githubId: props.githubId }).go();
   return user.data;
 }

--- a/functions/user/create.ts
+++ b/functions/user/create.ts
@@ -1,12 +1,12 @@
-import { create, EmailNotUniqueError } from "@/functions/core/entities/user";
+import { create, GithubIdNotUniqueError } from "@/functions/core/entities/user";
 import { ElectroValidationError } from "electrodb";
 import { ApiHandler, useJsonBody } from "sst/node/api";
 
 export const handler = ApiHandler(async () => {
-  const { email } = useJsonBody();
+  const { githubId } = useJsonBody();
 
   try {
-    const newUser = await create(email);
+    const newUser = await create({ githubId });
     return {
       body: JSON.stringify({
         user: newUser,
@@ -27,12 +27,12 @@ export const handler = ApiHandler(async () => {
           },
         }),
       };
-    } else if (e instanceof EmailNotUniqueError) {
+    } else if (e instanceof GithubIdNotUniqueError) {
       return {
         statusCode: 400,
         body: JSON.stringify({
           error: {
-            message: "Email already in use",
+            message: "Github ID already exists",
           },
         }),
       };
@@ -43,7 +43,7 @@ export const handler = ApiHandler(async () => {
   return {
     statusCode: 500,
     body: JSON.stringify({
-      error: "Internal server error",
+      error: "Could not create user",
     }),
   };
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6307,11 +6307,11 @@
       "dev": true
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
-      "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.1.tgz",
+      "integrity": "sha512-mFLFa2sSvlUxm55U7B4YCIsJJIMkA6lHxwwqOaBkral1qxFz97rGffP/mmd4JDuin1EnygiO5eNJGgudiUgmDQ==",
       "dependencies": {
-        "@smithy/types": "^1.0.0",
+        "@smithy/types": "^1.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -6319,9 +6319,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
-      "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.1.tgz",
+      "integrity": "sha512-tMpkreknl2gRrniHeBtdgQwaOlo39df8RxSrwsHVNIGXULy5XP6KqgScUw2m12D15wnJCKWxVhCX+wbrBW/y7g==",
       "dependencies": {
         "tslib": "^2.5.0"
       },

--- a/stacks/Authentication.ts
+++ b/stacks/Authentication.ts
@@ -1,12 +1,18 @@
-import { Auth, StackContext, use } from "sst/constructs";
+import { Auth, Config, StackContext, use } from "sst/constructs";
 import { API } from "./API";
 
 export function Authentication({ stack }: StackContext) {
   const { api } = use(API);
 
+  // See how to set secret values via sst:
+  // https://docs.sst.dev/config#should-i-use-configsecret-or-env-for-secrets
+  const GITHUB_CLIENT_ID = new Config.Secret(stack, "GITHUB_CLIENT_ID");
+  const GITHUB_CLIENT_SECRET = new Config.Secret(stack, "GITHUB_CLIENT_SECRET");
+
   const auth = new Auth(stack, "auth", {
     authenticator: {
       handler: "functions/auth.handler",
+      bind: [GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET],
     },
   });
 


### PR DESCRIPTION
Originally, I had planned on using SST's [magic links](https://docs.sst.dev/auth#magic-links) for authentication by sending links to user emails via AWS SES. However, to use SES in a production mode, I need to [request my account's SES to exit sandbox mode](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html) and provide proof that I have methods to handle complaints and spam.

This is more effort than I want for a side project, so I'm pivoting to SST's built in [GitHub auth handler](https://docs.sst.dev/auth#github) instead. 